### PR TITLE
Fix layout head slot for SEO metadata

### DIFF
--- a/src/components/SeoHead.astro
+++ b/src/components/SeoHead.astro
@@ -12,15 +12,17 @@ const title = p.title ?? 'San Diego Handyman Pros'
 const desc = p.description ?? 'Local handyman services in San Diego and North County.'
 const card = p.twitter?.card ?? 'summary_large_image'
 ---
-<title>{title}</title>
-<meta name="description" content={desc} />
-<link rel="canonical" href={url} />
-<meta property="og:type" content="website" />
-<meta property="og:title" content={title} />
-<meta property="og:description" content={desc} />
-<meta property="og:url" content={url} />
-{p.ogImage && <meta property="og:image" content={p.ogImage} />}
-<meta name="twitter:card" content={card} />
-<meta name="twitter:title" content={title} />
-<meta name="twitter:description" content={desc} />
-{p.ogImage && <meta name="twitter:image" content={p.ogImage} />}
+<Fragment slot="head">
+  <title>{title}</title>
+  <meta name="description" content={desc} />
+  <link rel="canonical" href={url} />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={desc} />
+  <meta property="og:url" content={url} />
+  {p.ogImage && <meta property="og:image" content={p.ogImage} />}
+  <meta name="twitter:card" content={card} />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={desc} />
+  {p.ogImage && <meta name="twitter:image" content={p.ogImage} />}
+</Fragment>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro Basics</title>
-	</head>
+        <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width" />
+                <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+                <meta name="generator" content={Astro.generator} />
+                <slot name="head" />
+        </head>
 	<body>
 		<slot />
 	</body>


### PR DESCRIPTION
## Summary
- remove the hard-coded document title from the layout and expose a head slot
- ensure SeoHead places its meta tags in the layout head slot for correct rendering

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dcbac8d188832cb42d3d201cc854e3