### PR TITLE
Fix Base layout CSS imports

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,8 @@
 import Layout from './Layout.astro'
 import SiteHeader from '../components/SiteHeader.astro'
 import SiteFooter from '../components/SiteFooter.astro'
+import '../styles/tailwind.css'
+import '../styles/components.css'
 ---
 <Layout>
   <SiteHeader />

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,0 +1,21 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f9fafb;
+  color: #0f172a;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: #1d4ed8;
+}
+
+main {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- import the shared Tailwind bundle and supporting component styles in the Base layout
- add a lightweight components.css file for baseline typography and color treatment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcc2c2eb30832c800e72790bf7e714